### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Added
 
-- Feature: Added erros to create payment
+- Feature: Added errors to create payment
 
 ## [0.1.0] - 2024-08-15
 


### PR DESCRIPTION
## Summary
- fix spelling mistake in `CHANGELOG.md`

## Testing
- `bundle exec rake spec` *(fails: `bundle` not found)*
- `rspec` *(fails: command not found)*