### PR TITLE
Fix README compensation report snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To query the status of a payment, use the payment ID:
     start_date = Date.new(2024, 11, 1)
     end_date = Date.new(2024, 11, 30)
     SveaPayments::Reports.get_compensation_report(start_date, end_date, seller_id, token)
-    SveaPayments::Reports.get_compensation_report(start_date, end_date, seller_id, token, format: 'CSV', key_generation: '004)
+    SveaPayments::Reports.get_compensation_report(start_date, end_date, seller_id, token, format: 'CSV', key_generation: '004')
 
 ## Development
 


### PR DESCRIPTION
## Summary
- close the string and method call in the compensation report example

## Testing
- `bundle exec rake spec` *(fails: `bundle: command not found`)*