### PR TITLE
Remove debug print from reports spec

### DIFF
--- a/spec/integration/reports_spec.rb
+++ b/spec/integration/reports_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe SveaPayments::Reports, :type => :request do
 
     it 'successfully retrieves compensation report in XML format' do
       response = described_class.get_compensation_report(start_date, end_date, seller_id, token)
-      puts response.inspect
       # Verify response structure
       expect(response).to include(
         'version',


### PR DESCRIPTION
## Summary
- remove noisy debug output from reports integration spec

## Testing
- `bundle exec rake spec` *(fails: Could not find rake-13.1.0, rspec-3.13.0, nokogiri-1.16.2-x86_64-linux... in locally installed gems)*