### PR TITLE
Fix basic auth token method

### DIFF
--- a/lib/svea_payments/authentication.rb
+++ b/lib/svea_payments/authentication.rb
@@ -6,9 +6,7 @@ module SveaPayments
     extend Base
     def self.get_basic_auth_token(username, password)
       base64_user_pass = Base64.strict_encode64("#{username}:#{password}")
-      uri = URI("#{SveaPayments.base_url}/NewPaymentExtended.pmt")
-      request = Net::HTTP::Get.new(uri)
-      request["Authorization"] = "Basic #{base64_user_pass}"
+      "Basic #{base64_user_pass}"
     end
   end
 end


### PR DESCRIPTION
## Summary
- simplify auth token generation

## Testing
- `bundle3.2 exec rspec` *(fails: command not found: rspec)*