### PR TITLE
Fix basic auth token method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ end
 Refer to the Svea Payments API documentation and this gem's tests: https://sveapayments.atlassian.net/wiki/spaces/DOCS/overview?homepageId=65539
 ### Authentication
 
-First, obtain an authentication token:
+First, obtain an authentication token. The returned string can be used as the
+value for the `Authorization` HTTP header:
 
     token = SveaPayments::Authentication.get_basic_auth_token(username, password)
 

--- a/lib/svea_payments/authentication.rb
+++ b/lib/svea_payments/authentication.rb
@@ -4,11 +4,11 @@ require 'base64'
 module SveaPayments
   class Authentication
     extend Base
+    # Returns a value suitable for the HTTP Authorization header
+    # using basic access authentication.
     def self.get_basic_auth_token(username, password)
       base64_user_pass = Base64.strict_encode64("#{username}:#{password}")
-      uri = URI("#{SveaPayments.base_url}/NewPaymentExtended.pmt")
-      request = Net::HTTP::Get.new(uri)
-      request["Authorization"] = "Basic #{base64_user_pass}"
+      "Basic #{base64_user_pass}"
     end
   end
 end


### PR DESCRIPTION
## Summary
- clarify usage of `get_basic_auth_token`
- document the method

## Testing
- `bundle3.2 exec rake` *(fails: Bundler::GemNotFound)*